### PR TITLE
Fix bottom padding for different Android navigation types

### DIFF
--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/login/LoginScreen.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/login/LoginScreen.kt
@@ -55,7 +55,7 @@ fun LoginScreen(
 
                 Toast.makeText(
                     LocalContext.current,
-                    "User fail ${it.exception?.message}",
+                    "Failed to login: ${it.exception?.message}",
                     Toast.LENGTH_LONG,
                 ).show()
             }
@@ -64,7 +64,7 @@ fun LoginScreen(
                 onLoggedIn()
                 Toast.makeText(
                     LocalContext.current,
-                    "User logged",
+                    "Logged in",
                     Toast.LENGTH_LONG,
                 ).show()
             }

--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/login/components/LoginBottomBar.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/login/components/LoginBottomBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
@@ -12,31 +13,36 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import com.projectlab.core.presentation.designsystem.theme.spacing
 
 @Composable
 fun LoginBottomBar(
     modifier: Modifier = Modifier,
-    onRegisterClick: () -> Unit
+    onRegisterClick: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(bottom = 20.dp)
+            .padding(bottom = MaterialTheme.spacing.regular)
+            .navigationBarsPadding()
             .clickable { onRegisterClick() },
         horizontalArrangement = Arrangement.Center,
     ) {
         Text(
             text = "Doesn’t have account on discover?",
-            style = MaterialTheme.typography.labelSmall.copy(color = MaterialTheme.colorScheme.onSurfaceVariant)
+            style = MaterialTheme.typography.labelSmall.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         )
-        Spacer(modifier = Modifier.width(4.dp))
+
+        Spacer(modifier = Modifier.width(MaterialTheme.spacing.extraSmall))
+
         Text(
             text = "Create Account",
             style = MaterialTheme.typography.labelSmall.copy(
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground
-            )
+                color = MaterialTheme.colorScheme.onBackground,
+            ),
         )
     }
 }

--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/login/components/LoginContent.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/login/components/LoginContent.kt
@@ -16,17 +16,20 @@ import com.projectlab.travelin_android.presentation.screens.login.LoginViewModel
 fun LoginContent(
     modifier: Modifier = Modifier,
     paddingValues: PaddingValues,
-    viewModel: LoginViewModel
+    viewModel: LoginViewModel,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(paddingValues),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(70.dp))
+
         LoginHeader()
+
         Spacer(modifier = Modifier.height(20.dp))
+
         LoginForm(viewModel = viewModel)
     }
 }

--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/profile/ProfileViewModel.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/profile/ProfileViewModel.kt
@@ -38,16 +38,16 @@ class ProfileViewModel @Inject constructor(
         getUserById()
     }
 
+    fun logout() {
+        viewModelScope.launch {
+            userSessionProvider.deleteUserSession()
+        }
+        authUseCase.logout()
+    }
+
     private fun getUserById() = viewModelScope.launch {
         usersUseCases.getUserById(currentUser!!.uid).collect {
             user = it
-
-        }
-        fun logout() {
-            viewModelScope.launch {
-                userSessionProvider.deleteUserSession()
-            }
-            authUseCase.logout()
         }
     }
 }

--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/profile/components/ProfileContent.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/profile/components/ProfileContent.kt
@@ -20,13 +20,13 @@ fun ProfileContent(
     modifier: Modifier = Modifier,
     paddingValues: PaddingValues,
     viewModel: ProfileViewModel,
-    onLogoutClick: () -> Unit
+    onLogoutClick: () -> Unit,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(paddingValues),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(modifier = Modifier.height(MaterialTheme.spacing.BigSpacing))
         ProfileUser(viewModel = viewModel)
@@ -36,14 +36,15 @@ fun ProfileContent(
                 .fillMaxWidth()
                 .height(MaterialTheme.spacing.Spacer)
                 .padding(horizontal = MaterialTheme.spacing.ScreenHorizontalPadding)
-                .background(MaterialTheme.colorScheme.surfaceDim)
+                .background(MaterialTheme.colorScheme.surfaceDim),
         )
         Spacer(modifier = Modifier.height(MaterialTheme.spacing.ScreenHorizontalPadding))
         ProfileSettings(
             viewModel = viewModel,
             onLogoutClick = {
+                viewModel.logout()
                 onLogoutClick()
-            }
+            },
         )
     }
 }

--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/register/RegisterScreen.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/register/RegisterScreen.kt
@@ -3,6 +3,7 @@ package com.projectlab.travelin_android.presentation.screens.register
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -20,12 +21,10 @@ fun RegisterScreen(
     viewModel: RegisterViewModel,
     onLoginClick: () -> Unit,
     onSuccessfulClick: () -> Unit,
-
-    ) {
+) {
     Scaffold(
-        topBar = { },
         content = { RegisterContent(paddingValues = it, viewModel = viewModel) },
-        bottomBar = { RegisterBottomBar(onLoginClick) }
+        bottomBar = { RegisterBottomBar(onLoginClick = onLoginClick) },
     )
 
     val registerFlow = viewModel.registerFlow.collectAsState()

--- a/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/register/components/RegisterBottomBar.kt
+++ b/auth/presentation/src/main/java/com/projectlab/travelin_android/presentation/screens/register/components/RegisterBottomBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
@@ -12,32 +13,36 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import com.projectlab.core.presentation.designsystem.theme.spacing
 
 @Composable
 fun RegisterBottomBar(
     onLoginClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(bottom = 20.dp)
+            .padding(bottom = MaterialTheme.spacing.regular)
+            .navigationBarsPadding()
             .clickable { onLoginClick() },
         horizontalArrangement = Arrangement.Center,
     ) {
         Text(
             text = "Already have an account?",
             style = MaterialTheme.typography.labelMedium.copy(
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         )
-        Spacer(modifier = Modifier.width(4.dp))
+
+        Spacer(modifier = Modifier.width(MaterialTheme.spacing.extraSmall))
+
         Text(
             text = "Go back",
             style = MaterialTheme.typography.labelMedium.copy(
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         )
     }
 }

--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/BottomNavigationBar.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/BottomNavigationBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -24,7 +25,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.projectlab.core.presentation.designsystem.theme.spacing
 
@@ -47,6 +51,19 @@ fun BottomNavigationBar(
         tonalElevation = MaterialTheme.spacing.TinySpacing,
         shadowElevation = MaterialTheme.spacing.SectionSpacing,
         color = Color.Transparent,
+        modifier = Modifier
+            .navigationBarsPadding()
+            .drawWithContent {
+                // clip left, right, and bottom
+                clipRect(
+                    left = 0f,
+                    top = -Float.MAX_VALUE,
+                    right = size.width,
+                    bottom = size.height,
+                ) {
+                    this@drawWithContent.drawContent()
+                }
+            },
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION
With the current configuration, the navigation controls — be it gestures, or 2/3-button navigation — from Android overlap with the components displayed at the bottom of the screen.

To fix this we must use Modifier.navigationBarsPadding() to ensure these components are drawn above the Android navigation controls.

PS: Also took the chance to fix the logout button in the profile screen.
