### PR TITLE
feat: hotels home carousel and favorites plus extra improvements

### DIFF
--- a/app/src/main/java/com/projectlab/travelin_android/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/projectlab/travelin_android/navigation/NavigationRoot.kt
@@ -21,6 +21,7 @@ import com.projectlab.booking.presentation.home.HomeScreen
 import com.projectlab.booking.presentation.HotelsViewModel
 import com.projectlab.booking.presentation.detail.hotels.HomeHotelDetailScreen
 import com.projectlab.booking.presentation.detail.hotels.HomeHotelDetailViewModel
+import com.projectlab.booking.presentation.favorites.FavoritesViewModel
 import com.projectlab.booking.presentation.home.HomeViewModel
 import com.projectlab.booking.presentation.screens.hotels.details.DetailHotelScreen
 import com.projectlab.booking.presentation.search.hotels.SearchHotelScreen
@@ -114,6 +115,7 @@ private fun NavGraphBuilder.searchGraph(navController: NavHostController) {
         SearchActivityScreen(
             locationViewModel = hiltViewModel(),
             searchActivityViewModel = hiltViewModel(),
+            favoritesViewModel = hiltViewModel(),
             initialQuery = query,
             onActivityClick = { activityId ->
                 navController.navigate(DetailScreens.ActivityDetail.createRoute(activityId))
@@ -131,10 +133,12 @@ private fun NavGraphBuilder.searchGraph(navController: NavHostController) {
 
         val locationViewModel: LocationViewModel = hiltViewModel()
         val searchActivityViewModel: SearchActivityViewModel = hiltViewModel()
+        val favoritesViewModel: FavoritesViewModel = hiltViewModel()
 
         SearchActivityScreen(
             locationViewModel = locationViewModel,
             searchActivityViewModel = searchActivityViewModel,
+            favoritesViewModel = favoritesViewModel,
             initialQuery = query,
             onActivityClick = { activityId ->
                 navController.navigate(DetailScreens.ActivityDetail.createRoute(activityId))
@@ -164,6 +168,7 @@ private fun NavGraphBuilder.detailGraph(navController: NavHostController) {
 
         ActivityDetailScreen(
             activityDetailViewModel = hiltViewModel<ActivityDetailViewModel>(),
+            favoritesViewModel = hiltViewModel(),
             activityId = activityId,
             onBackClick = { navController.popBackStack() }
         )

--- a/app/src/main/java/com/projectlab/travelin_android/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/projectlab/travelin_android/navigation/NavigationRoot.kt
@@ -3,7 +3,6 @@ package com.projectlab.travelin_android.navigation
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
@@ -18,9 +17,11 @@ import com.projectlab.booking.presentation.booking.successful.BookingSuccessfulS
 import com.projectlab.booking.presentation.detail.activities.ActivityDetailScreen
 import com.projectlab.booking.presentation.detail.activities.ActivityDetailViewModel
 import com.projectlab.booking.presentation.favorites.FavoritesScreen
-import com.projectlab.booking.presentation.favorites.FavoritesViewModel
 import com.projectlab.booking.presentation.home.HomeScreen
 import com.projectlab.booking.presentation.HotelsViewModel
+import com.projectlab.booking.presentation.detail.hotels.HomeHotelDetailScreen
+import com.projectlab.booking.presentation.detail.hotels.HomeHotelDetailViewModel
+import com.projectlab.booking.presentation.home.HomeViewModel
 import com.projectlab.booking.presentation.screens.hotels.details.DetailHotelScreen
 import com.projectlab.booking.presentation.search.hotels.SearchHotelScreen
 import com.projectlab.booking.presentation.search.activities.SearchActivityScreen
@@ -108,17 +109,17 @@ private fun NavGraphBuilder.authGraph(navController: NavHostController) {
 
 private fun NavGraphBuilder.searchGraph(navController: NavHostController) {
 
-    composable(route = SearchScreens.Activities.route) {
+    composable(route = SearchScreens.Activities.route) { backStackEntry ->
+        val query = backStackEntry.arguments?.getString("query").orEmpty()
         SearchActivityScreen(
             locationViewModel = hiltViewModel(),
             searchActivityViewModel = hiltViewModel(),
-            favoritesViewModel = hiltViewModel(),
-            navController = navController,
+            initialQuery = query,
             onActivityClick = { activityId ->
                 navController.navigate(DetailScreens.ActivityDetail.createRoute(activityId))
-            }
+            },
+            onBackClick = { navController.popBackStack() }
         )
-
     }
 
     composable(
@@ -130,20 +131,15 @@ private fun NavGraphBuilder.searchGraph(navController: NavHostController) {
 
         val locationViewModel: LocationViewModel = hiltViewModel()
         val searchActivityViewModel: SearchActivityViewModel = hiltViewModel()
-        val favoritesViewModel: FavoritesViewModel = hiltViewModel()
-
-        LaunchedEffect(query) {
-            searchActivityViewModel.searchWithInitialQuery(query)
-        }
 
         SearchActivityScreen(
             locationViewModel = locationViewModel,
             searchActivityViewModel = searchActivityViewModel,
-            favoritesViewModel = favoritesViewModel,
-            navController = navController,
+            initialQuery = query,
             onActivityClick = { activityId ->
                 navController.navigate(DetailScreens.ActivityDetail.createRoute(activityId))
             },
+            onBackClick = { navController.popBackStack() }
         )
 
     }
@@ -169,8 +165,6 @@ private fun NavGraphBuilder.detailGraph(navController: NavHostController) {
         ActivityDetailScreen(
             activityDetailViewModel = hiltViewModel<ActivityDetailViewModel>(),
             activityId = activityId,
-            navController = navController,
-            favoritesViewModel = hiltViewModel(),
             onBackClick = { navController.popBackStack() }
         )
     }
@@ -193,22 +187,43 @@ private fun NavGraphBuilder.detailGraph(navController: NavHostController) {
             onClickBookingHotel = { navController.navigate(BookingScreens.HotelBooking.route) }
         )
     }
+
+    composable(route = DetailScreens.HomeHotelDetail.route) { backStackEntry ->
+        val parentEntry = remember(backStackEntry) {
+            navController.getBackStackEntry(HomeScreens.Home.route)
+        }
+        val viewModel: HomeHotelDetailViewModel = hiltViewModel(parentEntry)
+
+        HomeHotelDetailScreen(
+            viewModel = viewModel,
+            onClickBack = { navController.popBackStack() },
+            onClickBookingHotel = { navController.navigate(BookingScreens.HotelBooking.route) }
+        )
+    }
 }
 
 private fun NavGraphBuilder.homeGraph(navController: NavHostController) {
+
     composable(route = HomeScreens.Home.route) {
+        val locationViewModel: LocationViewModel = hiltViewModel()
+        val homeViewModel: HomeViewModel = hiltViewModel()
+        val homeHotelDetailViewModel: HomeHotelDetailViewModel = hiltViewModel()
+
         HomeScreen(
-            locationViewModel = hiltViewModel(),
-            homeViewModel = hiltViewModel(),
-            navController = navController,
+            locationViewModel = locationViewModel,
+            homeViewModel = homeViewModel,
             onClickSearchHotel = { navController.navigate(SearchScreens.Hotels.route) },
             onFavoritesClick = { navController.navigate(FavoritesScreens.Favorites.route) },
             onTripsClick = {},
             onProfileClick = { navController.navigate(AuthScreens.Profile.route) },
-            onItemClick = { activityId ->
+            onActivityItemClick = { activityId ->
                 navController.navigate(DetailScreens.ActivityDetail.createRoute(activityId))
             },
-            favoritesViewModel = hiltViewModel()
+            onHotelItemClick = { hotel ->
+                homeHotelDetailViewModel.selectHotel(hotel)
+                navController.navigate(DetailScreens.HomeHotelDetail.route)
+            },
+            navController = navController
         )
     }
 }

--- a/app/src/main/java/com/projectlab/travelin_android/navigation/Screens.kt
+++ b/app/src/main/java/com/projectlab/travelin_android/navigation/Screens.kt
@@ -71,6 +71,12 @@ sealed interface DetailScreens {
         override val route = "hotelDetail/{hotelId}"
         fun createRoute(hotelId: String): String = "hotelDetail/$hotelId"
     }
+
+    @Serializable
+    data object HomeHotelDetail : DetailScreens {
+        override val route = "home/hotelDetail/{hotelId}"
+        fun createRoute(hotelId: String): String = "hotelDetail/$hotelId"
+    }
 }
 
 sealed interface HomeScreens {

--- a/booking/presentation/src/androidTest/java/com/projectlab/booking/presentation/HomeViewModelTest.kt
+++ b/booking/presentation/src/androidTest/java/com/projectlab/booking/presentation/HomeViewModelTest.kt
@@ -9,16 +9,20 @@ import com.projectlab.core.domain.model.Location
 import com.projectlab.core.domain.proto.SearchHistory.HistoryType
 import com.projectlab.core.domain.repository.ActivityRepository
 import com.projectlab.core.domain.repository.SearchHistoryProvider
-import com.projectlab.core.domain.repository.UserSessionProvider
 import com.projectlab.core.domain.use_cases.activities.GetActivitiesUseCase
+import com.projectlab.core.domain.use_cases.activities.RemoveFavoriteActivityByIdUseCase
+import com.projectlab.core.domain.use_cases.activities.SaveFavoriteActivityUseCase
 import com.projectlab.core.domain.use_cases.error.ErrorMapper
+import com.projectlab.core.domain.use_cases.hotels.GetFavoriteHotelsUseCase
+import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCoordinatesUseCase
+import com.projectlab.core.domain.use_cases.hotels.RemoveFavoriteHotelUseCase
+import com.projectlab.core.domain.use_cases.hotels.SaveFavoriteHotelUseCase
 import com.projectlab.core.domain.use_cases.location.GetCoordinatesFromCityUseCase
 import com.projectlab.core.domain.util.Result
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.After
 import org.mockito.Mockito.mock
@@ -42,7 +46,12 @@ class HomeViewModelTest {
     private val historyProvider = mock<SearchHistoryProvider>()
     private val getCoordinatesFromCityUseCase = mock<GetCoordinatesFromCityUseCase>()
     private val activityRepository = mock<ActivityRepository>()
-
+    private val getHotelsByCoordinatesUseCase = mock<GetHotelsByCoordinatesUseCase>()
+    private val saveFavoriteActivityUseCase = mock<SaveFavoriteActivityUseCase>()
+    private val saveFavoriteHotelUseCase = mock<SaveFavoriteHotelUseCase>()
+    private val removeFavoriteActivityByIdUseCase = mock<RemoveFavoriteActivityByIdUseCase>()
+    private val getFavoriteHotelsUseCase = mock<GetFavoriteHotelsUseCase>()
+    private val removeFavoriteHotelUseCase = mock<RemoveFavoriteHotelUseCase>()
 
     private lateinit var homeViewModel: HomeViewModel
 
@@ -53,12 +62,18 @@ class HomeViewModelTest {
         Dispatchers.setMain(dispatcher)
 
         homeViewModel = HomeViewModel(
-            getActivitiesUseCase,
-            errorMapper,
-            historyProvider,
-            getCoordinatesFromCityUseCase,
-            activityRepository,
-            dispatcher
+            getActivitiesUseCase = getActivitiesUseCase,
+            errorMapper = errorMapper,
+            historyProvider = historyProvider,
+            getCoordinatesFromCityUseCase = getCoordinatesFromCityUseCase,
+            getHotelsByCoordinatesUseCase = getHotelsByCoordinatesUseCase,
+            saveFavoriteActivityUseCase = saveFavoriteActivityUseCase,
+            saveFavoriteHotelUseCase = saveFavoriteHotelUseCase,
+            removeFavoriteActivityByIdUseCase = removeFavoriteActivityByIdUseCase,
+            getFavoriteHotelsUseCase = getFavoriteHotelsUseCase,
+            removeFavoriteHotelUseCase = removeFavoriteHotelUseCase,
+            activityRepository = activityRepository,
+            dispatcher = dispatcher
         )
     }
 
@@ -119,7 +134,8 @@ class HomeViewModelTest {
 
         val dtoActivities = fakeActivities.map { it.toDto() }
 
-        Mockito.`when`(getActivitiesUseCase(10.500000, -66.916664)).thenReturn(Result.Success(fakeActivities))
+        Mockito.`when`(getActivitiesUseCase(10.500000, -66.916664))
+            .thenReturn(Result.Success(fakeActivities))
         Mockito.`when`(activityRepository.getFavoriteActivities())
             .thenReturn(flowOf(emptyList()))
 
@@ -137,7 +153,8 @@ class HomeViewModelTest {
 
         val favoriteActivities = listOf(fakeFavoriteActivities.first())
 
-        Mockito.`when`(activityRepository.getFavoriteActivities()).thenReturn(flowOf(favoriteActivities))
+        Mockito.`when`(activityRepository.getFavoriteActivities())
+            .thenReturn(flowOf(favoriteActivities))
 
         homeViewModel.fetchFavoriteActivities()
         advanceUntilIdle()

--- a/booking/presentation/src/androidTest/java/com/projectlab/booking/presentation/SearchActivityViewModelTest.kt
+++ b/booking/presentation/src/androidTest/java/com/projectlab/booking/presentation/SearchActivityViewModelTest.kt
@@ -2,6 +2,7 @@ package com.projectlab.booking.presentation
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.projectlab.booking.presentation.search.activities.SearchActivityViewModel
+import com.projectlab.core.domain.repository.ActivityRepository
 import com.projectlab.core.domain.repository.SearchHistoryProvider
 import com.projectlab.core.domain.use_cases.activities.GetActivitiesUseCase
 import com.projectlab.core.domain.use_cases.activities.RemoveFavoriteActivityByIdUseCase
@@ -26,6 +27,7 @@ class SearchActivityViewModelTest {
     private val historyProvider = mock<SearchHistoryProvider>()
     private val saveFavoriteActivityUseCase = mock<SaveFavoriteActivityUseCase>()
     private val removeFavoriteActivityByIdUseCase = mock<RemoveFavoriteActivityByIdUseCase>()
+    private val activityRepository = mock<ActivityRepository>()
 
     private val searchActivityViewModel = SearchActivityViewModel(
         getActivitiesUseCase = getActivitiesUseCase,
@@ -34,7 +36,8 @@ class SearchActivityViewModelTest {
         errorMapper = errorMapper,
         historyProvider = historyProvider,
         saveFavoriteActivityUseCase = saveFavoriteActivityUseCase,
-        removeFavoriteActivityByIdUseCase = removeFavoriteActivityByIdUseCase
+        removeFavoriteActivityByIdUseCase = removeFavoriteActivityByIdUseCase,
+        activityRepository = activityRepository
     )
 
     @Test

--- a/booking/presentation/src/main/java/com/projectlab/booking/di/BookingPresentationModule.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/di/BookingPresentationModule.kt
@@ -1,13 +1,17 @@
 package com.projectlab.booking.presentation.di
 
+import com.projectlab.core.data.usecase.GetFavoriteHotelsUseCaseImpl
+import com.projectlab.core.data.usecase.RemoveFavoriteHotelUseCaseImpl
+import com.projectlab.core.data.usecase.SaveFavoriteHotelUseCaseImpl
 import com.projectlab.core.domain.repository.HotelsRepository
-import com.projectlab.core.domain.repository.UsersRepository
 import com.projectlab.core.domain.use_cases.hotels.FavoriteHotelUseCase
+import com.projectlab.core.domain.use_cases.hotels.GetFavoriteHotelsUseCase
 import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCityUseCase
-import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCoordinatesUseCase
+import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCoordinatesUseCaseImpl
 import com.projectlab.core.domain.use_cases.hotels.HotelsUseCases
+import com.projectlab.core.domain.use_cases.hotels.RemoveFavoriteHotelUseCase
+import com.projectlab.core.domain.use_cases.hotels.SaveFavoriteHotelUseCase
 import com.projectlab.core.domain.use_cases.hotels.UnfavoriteHotelUseCase
-import com.projectlab.core.domain.use_cases.users.UsersUseCases
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,6 +25,30 @@ object BookingPresentationModule {
         getHotelsByCity = GetHotelsByCityUseCase(repository),
         favoriteHotel = FavoriteHotelUseCase(repository),
         unfavoriteHotel = UnfavoriteHotelUseCase(repository),
-        getHotelsByCoordinates = GetHotelsByCoordinatesUseCase(repository),
+        getHotelsByCoordinates = GetHotelsByCoordinatesUseCaseImpl(repository),
+        saveFavoriteHotelUseCase = SaveFavoriteHotelUseCaseImpl(repository),
+        getFavoriteHotelsUseCase = GetFavoriteHotelsUseCaseImpl(repository),
+        removeFavoriteHotelUseCase = RemoveFavoriteHotelUseCaseImpl(repository)
     )
+
+    @Provides
+    fun provideRemoveFavoriteHotelUseCase(
+        repository: HotelsRepository
+    ): RemoveFavoriteHotelUseCase {
+        return RemoveFavoriteHotelUseCaseImpl(repository)
+    }
+
+    @Provides
+    fun provideSaveFavoriteHotelUseCase(
+        repository: HotelsRepository
+    ): SaveFavoriteHotelUseCase {
+        return SaveFavoriteHotelUseCaseImpl(repository)
+    }
+
+    @Provides
+    fun provideGetFavoriteHotelsUseCase(
+        repository: HotelsRepository
+    ): GetFavoriteHotelsUseCase {
+        return GetFavoriteHotelsUseCaseImpl(repository)
+    }
 }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/HotelsViewModel.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/HotelsViewModel.kt
@@ -16,6 +16,8 @@ import com.projectlab.core.domain.model.Hotel
 import com.projectlab.core.domain.model.User
 import com.projectlab.core.domain.repository.UserSessionProvider
 import com.projectlab.core.domain.use_cases.hotels.HotelsUseCases
+import com.projectlab.core.domain.use_cases.hotels.RemoveFavoriteHotelUseCase
+import com.projectlab.core.domain.use_cases.hotels.SaveFavoriteHotelUseCase
 import com.projectlab.core.domain.use_cases.location.GetCoordinatesFromCityUseCase
 import com.projectlab.core.domain.use_cases.users.UsersUseCases
 import com.projectlab.core.domain.util.Result
@@ -34,7 +36,9 @@ class HotelsViewModel @Inject constructor(
     private val hotelsUseCases: HotelsUseCases,
     private val usersUseCases: UsersUseCases,
     private val userSessionProvider: UserSessionProvider,
-    private val getCoordinatesFromCityUseCase: GetCoordinatesFromCityUseCase
+    private val getCoordinatesFromCityUseCase: GetCoordinatesFromCityUseCase,
+    private val saveFavoriteHotelUseCase: SaveFavoriteHotelUseCase,
+    private val removeFavoriteHotelUseCase: RemoveFavoriteHotelUseCase
 
 ) : ViewModel() {
 
@@ -147,30 +151,20 @@ class HotelsViewModel @Inject constructor(
     fun favoriteHotel(hotel: Hotel) {
         viewModelScope.launch {
             try {
-                when (hotelsUseCases.favoriteHotel(user.id, hotel)) {
+                when (saveFavoriteHotelUseCase(hotel)) {
                     is Result.Success -> {
-
                         val updatedHotels = _uiStateHotelSearch.value.hotels.map {
-                            if (it == hotel) {
-                                it.copy(isFavourite = true)
-                            } else {
-                                it
-                            }
+                            if (it.id == hotel.id) it.copy(isFavourite = true) else it
                         }
                         _uiStateHotelSearch.update { it.copy(hotels = updatedHotels) }
                     }
 
                     is Result.Error -> {
-                        _uiStateHotelSearch.update { it.copy(error = "Unknown error") }
+                        _uiStateHotelSearch.update { it.copy(error = "Error saving favorite") }
                     }
-
                 }
-
             } catch (e: Exception) {
-                println(e)
-
-            } finally {
-                _uiStateHotelSearch.update { it.copy(isLoading = false) }
+                _uiStateHotelSearch.update { it.copy(error = e.message ?: "Unknown error") }
             }
         }
     }
@@ -178,28 +172,20 @@ class HotelsViewModel @Inject constructor(
     fun unfavoriteHotel(hotelId: String) {
         viewModelScope.launch {
             try {
-                when (hotelsUseCases.unfavoriteHotel(hotelId)) {
+                when (removeFavoriteHotelUseCase(hotelId)) {
                     is Result.Success -> {
-
                         val updatedHotels = _uiStateHotelSearch.value.hotels.map {
-                            if (it.id == hotelId) {
-                                it.copy(isFavourite = false)
-                            } else {
-                                it
-                            }
+                            if (it.id == hotelId) it.copy(isFavourite = false) else it
                         }
                         _uiStateHotelSearch.update { it.copy(hotels = updatedHotels) }
                     }
 
                     is Result.Error -> {
-                        _uiStateHotelSearch.update { it.copy(error = "Unknown error") }
+                        _uiStateHotelSearch.update { it.copy(error = "Error removing favorite") }
                     }
                 }
             } catch (e: Exception) {
-                println(e)
-
-            } finally {
-                _uiStateHotelSearch.update { it.copy(isLoading = false) }
+                _uiStateHotelSearch.update { it.copy(error = e.message ?: "Unknown error") }
             }
         }
     }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/HotelsViewModel.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/HotelsViewModel.kt
@@ -84,7 +84,9 @@ class HotelsViewModel @Inject constructor(
                 if (locationData != null) {
                     when (val result = hotelsUseCases.getHotelsByCoordinates(
                         locationData.first,
-                        locationData.second
+                        locationData.second,
+                        emptyList(),
+                        emptyList()
                     )) {
                         is Result.Success -> {
                             _uiStateHotelSearch.update { it.copy(hotels = result.data.toMutableList()) }
@@ -142,14 +144,14 @@ class HotelsViewModel @Inject constructor(
         _uiStateBookingHotel.update { it.copy(hotelUi = hotelFound!!.toHotelUi()) }
     }
 
-    fun favoriteHotel(hotelId: String) {
+    fun favoriteHotel(hotel: Hotel) {
         viewModelScope.launch {
             try {
-                when (hotelsUseCases.favoriteHotel(user.id, hotelId)) {
+                when (hotelsUseCases.favoriteHotel(user.id, hotel)) {
                     is Result.Success -> {
 
                         val updatedHotels = _uiStateHotelSearch.value.hotels.map {
-                            if (it.id == hotelId) {
+                            if (it == hotel) {
                                 it.copy(isFavourite = true)
                             } else {
                                 it
@@ -176,7 +178,7 @@ class HotelsViewModel @Inject constructor(
     fun unfavoriteHotel(hotelId: String) {
         viewModelScope.launch {
             try {
-                when (hotelsUseCases.unfavoriteHotel(user.id, hotelId)) {
+                when (hotelsUseCases.unfavoriteHotel(hotelId)) {
                     is Result.Success -> {
 
                         val updatedHotels = _uiStateHotelSearch.value.hotels.map {

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/activities/ActivityDetailScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/activities/ActivityDetailScreen.kt
@@ -22,9 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import com.projectlab.booking.presentation.favorites.FavoritesViewModel
 import com.projectlab.core.data.mapper.toFavoriteActivityEntity
 import com.projectlab.core.presentation.designsystem.component.BottomBookBar
 import com.projectlab.core.presentation.designsystem.component.DescriptionBox
@@ -38,9 +35,7 @@ import com.projectlab.core.presentation.designsystem.theme.spacing
 fun ActivityDetailScreen(
     modifier: Modifier = Modifier,
     activityDetailViewModel: ActivityDetailViewModel,
-    favoritesViewModel: FavoritesViewModel,
     activityId: String,
-    navController: NavController,
     onBackClick: () -> Unit
 ) {
     LaunchedEffect(Unit) {
@@ -48,15 +43,15 @@ fun ActivityDetailScreen(
     }
 
     val uiState by activityDetailViewModel.uiState.collectAsState()
-    val favoritesUiState by favoritesViewModel.uiState.collectAsState()
 
-    val favoriteIds by favoritesViewModel.favoriteActivityIds.collectAsState()
+
+    val favoriteIds by activityDetailViewModel.favoriteActivityIds.collectAsState()
     val isFavorite = favoriteIds.contains(activityId)
-    val isFavoriteLoading = favoritesUiState.isFavoriteLoading
+    val isFavoriteLoading = uiState.isFavoriteLoading
 
     val onFavoriteClick: () -> Unit = {
         uiState.activity?.let { activity ->
-            favoritesViewModel.toggleFavorite(activity.toFavoriteActivityEntity())
+            activityDetailViewModel.toggleFavoriteActivity(activity.toFavoriteActivityEntity())
         }
     }
 
@@ -72,7 +67,6 @@ fun ActivityDetailScreen(
         ActivityDetailScreenComponent(
             modifier = modifier,
             uiState = uiState,
-            navController = navController,
             onFavoriteClick = onFavoriteClick,
             isFavorite = isFavorite,
             isFavoriteLoading = isFavoriteLoading,
@@ -85,7 +79,6 @@ fun ActivityDetailScreen(
 fun ActivityDetailScreenComponent(
     modifier: Modifier = Modifier,
     uiState: ActivityDetailUiState,
-    navController: NavController,
     isFavorite: Boolean,
     isFavoriteLoading: Boolean,
     onFavoriteClick: () -> Unit,
@@ -112,7 +105,6 @@ fun ActivityDetailScreenComponent(
                 TourCardHeader(
                     modifier = Modifier,
                     activity = it,
-                    navController = navController,
                     isFavorite = isFavorite,
                     isFavoriteLoading = isFavoriteLoading,
                     onFavoriteClick = onFavoriteClick,

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/activities/ActivityDetailScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/activities/ActivityDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.projectlab.booking.presentation.favorites.FavoritesViewModel
 import com.projectlab.core.data.mapper.toFavoriteActivityEntity
 import com.projectlab.core.presentation.designsystem.component.BottomBookBar
 import com.projectlab.core.presentation.designsystem.component.DescriptionBox
@@ -35,6 +36,7 @@ import com.projectlab.core.presentation.designsystem.theme.spacing
 fun ActivityDetailScreen(
     modifier: Modifier = Modifier,
     activityDetailViewModel: ActivityDetailViewModel,
+    favoritesViewModel: FavoritesViewModel,
     activityId: String,
     onBackClick: () -> Unit
 ) {
@@ -43,15 +45,15 @@ fun ActivityDetailScreen(
     }
 
     val uiState by activityDetailViewModel.uiState.collectAsState()
+    val favoritesUiState by favoritesViewModel.uiState.collectAsState()
 
-
-    val favoriteIds by activityDetailViewModel.favoriteActivityIds.collectAsState()
+    val favoriteIds by favoritesViewModel.favoriteActivityIds.collectAsState()
     val isFavorite = favoriteIds.contains(activityId)
-    val isFavoriteLoading = uiState.isFavoriteLoading
+    val isFavoriteLoading = favoritesUiState.isFavoriteLoading
 
     val onFavoriteClick: () -> Unit = {
         uiState.activity?.let { activity ->
-            activityDetailViewModel.toggleFavoriteActivity(activity.toFavoriteActivityEntity())
+            favoritesViewModel.toggleFavoriteActivity(activity.toFavoriteActivityEntity())
         }
     }
 

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/hotels/HomeHotelDetailScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/hotels/HomeHotelDetailScreen.kt
@@ -1,0 +1,44 @@
+package com.projectlab.booking.presentation.detail.hotels
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import com.projectlab.booking.presentation.screens.hotels.details.components.DetailHotelBottomBar
+import com.projectlab.booking.presentation.screens.hotels.details.components.DetailHotelContent
+import com.projectlab.core.presentation.designsystem.component.HeaderWithBack
+
+@SuppressLint("SuspiciousIndentation")
+@Composable
+fun HomeHotelDetailScreen(
+    modifier: Modifier = Modifier,
+    viewModel: HomeHotelDetailViewModel,
+    onClickBack: () -> Unit,
+    onClickBookingHotel: () -> Unit
+) {
+    val hotel = viewModel.selectedHotel.collectAsState().value
+
+       Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            topBar = { HeaderWithBack(onClickBack = onClickBack) },
+            content = {
+                hotel?.let { hotelUi ->
+                    DetailHotelContent(
+                        modifier = modifier.padding(it),
+                        hotelUi = hotelUi
+                    )
+                }
+            },
+            bottomBar = {
+                hotel?.let {
+                    DetailHotelBottomBar(
+                        hotelUi = it,
+                        onClickBookingHotel = { onClickBookingHotel() }
+                    )
+                }
+            }
+        )
+    }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/hotels/HomeHotelDetailViewModel.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/detail/hotels/HomeHotelDetailViewModel.kt
@@ -1,0 +1,20 @@
+package com.projectlab.booking.presentation.detail.hotels
+
+import androidx.lifecycle.ViewModel
+import com.projectlab.booking.models.HotelUi
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+    @HiltViewModel
+    class HomeHotelDetailViewModel @Inject constructor(
+    ) : ViewModel() {
+
+        private val _selectedHotel = MutableStateFlow<HotelUi?>(null)
+        val selectedHotel: StateFlow<HotelUi?> = _selectedHotel
+
+        fun selectHotel(hotel: HotelUi) {
+            _selectedHotel.value = hotel
+        }
+    }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesScreen.kt
@@ -52,6 +52,7 @@ fun FavoritesScreen(
 ) {
     LaunchedEffect(Unit) {
         viewModel.queryFavoriteActivities()
+        viewModel.queryFavoriteHotels()
     }
 
     Scaffold(
@@ -89,7 +90,7 @@ private fun FavoritesScreenComponent(
     val onSearchPressed: () -> Unit = {
         when (selectedTab) {
             FavoriteTabItem.DESTINATIONS -> viewModel.queryFavoriteActivities()
-            FavoriteTabItem.HOTELS -> null // TODO
+            FavoriteTabItem.HOTELS -> viewModel.queryFavoriteHotels()
         }
     }
 
@@ -170,12 +171,12 @@ private fun FavoritesScreenComponent(
             ) {
                 when (selectedTab) {
                     FavoriteTabItem.DESTINATIONS -> {
-                        items(uiState.destinations) { favorite ->
+                        items(uiState.activities) { favorite ->
                             VerticalFavoriteCard(
                                 name = favorite.name,
                                 description = favorite.description,
-                                location = favorite.location,
-                                rating = favorite.rating,
+                                location = favorite.location.toString(),
+                                rating = favorite.rating.toString(),
                                 pictureUrl = favorite.pictures.getOrElse(0) { null },
                                 isFavorite = true,
                                 onFavoriteClick = { viewModel.removeFavoriteActivity(favorite.id) },
@@ -188,7 +189,20 @@ private fun FavoritesScreenComponent(
                     }
 
                     FavoriteTabItem.HOTELS -> {
-                        // TODO
+                        items(uiState.hotels) { hotel ->
+                            VerticalFavoriteCard(
+                                name = hotel.name,
+                                description = hotel.amenities.toString(),
+                                location = hotel.address,
+                                rating = hotel.rating.toString(),
+                                pictureUrl = hotel.displayImageUrl,
+                                isFavorite = true,
+                                onFavoriteClick = { viewModel.removeFavoriteHotel(hotel.id) },
+                                onClick = { onActivityClick(hotel.id) },
+                                modifier = Modifier
+                                    .height(MaterialTheme.spacing.favoriteCardHeight)
+                            )
+                        }
                     }
                 }
             }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesScreen.kt
@@ -97,7 +97,7 @@ private fun FavoritesScreenComponent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(vertical = MaterialTheme.spacing.regular),
+            .padding(top = MaterialTheme.spacing.regular),
     ) {
         SearchBar(
             query = uiState.query,
@@ -119,7 +119,6 @@ private fun FavoritesScreenComponent(
                 .padding(
                     start = MaterialTheme.spacing.semiLarge,
                     end = MaterialTheme.spacing.semiLarge,
-                    bottom = MaterialTheme.spacing.semiLarge,
                 ),
         ) {
             Text(

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesUIState.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesUIState.kt
@@ -1,13 +1,15 @@
 package com.projectlab.booking.presentation.favorites
 
 import com.projectlab.core.domain.entity.FavoriteActivityEntity
+import com.projectlab.core.domain.entity.FavoriteHotelEntity
 
 data class FavoritesUIState(
     val query: String = "",
     val isLoading: Boolean = false,
     val error: String? = null,
-    val destinations: List<FavoriteActivityEntity> = emptyList(),
+    val activities: List<FavoriteActivityEntity> = emptyList(),
+    val hotels: List<FavoriteHotelEntity> = emptyList(),
     val favoriteActivities: List<FavoriteActivityEntity> = emptyList(),
     val isFavoriteLoading: Boolean = false,
-    // TODO hotels
+    val isFavoriteHotel: Boolean = false
 )

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesViewModel.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/favorites/FavoritesViewModel.kt
@@ -3,9 +3,12 @@ package com.projectlab.booking.presentation.favorites
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.projectlab.core.domain.entity.FavoriteActivityEntity
+import com.projectlab.core.domain.entity.FavoriteHotelEntity
 import com.projectlab.core.domain.use_cases.activities.QueryFavoriteActivitiesUseCase
 import com.projectlab.core.domain.use_cases.activities.RemoveFavoriteActivityByIdUseCase
-import com.projectlab.core.domain.use_cases.activities.SaveFavoriteActivityUseCase
+import com.projectlab.core.domain.use_cases.hotels.QueryFavoriteHotelsUseCase
+import com.projectlab.core.domain.use_cases.hotels.RemoveFavoriteHotelUseCase
+import com.projectlab.core.domain.use_cases.location.GetCityFromCoordinatesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
@@ -22,7 +25,9 @@ import kotlin.coroutines.cancellation.CancellationException
 class FavoritesViewModel @Inject constructor(
     private val queryFavoriteActivitiesUseCase: QueryFavoriteActivitiesUseCase,
     private val removeFavoriteActivityByIdUseCase: RemoveFavoriteActivityByIdUseCase,
-    private val saveFavoriteActivityUseCase: SaveFavoriteActivityUseCase,
+    private val queryFavoriteHotelsUseCase: QueryFavoriteHotelsUseCase,
+    private val removeFavoriteHotelUseCase: RemoveFavoriteHotelUseCase,
+    private val getCityFromCoordinatesUseCase: GetCityFromCoordinatesUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(FavoritesUIState())
     val uiState: StateFlow<FavoritesUIState> = _uiState.asStateFlow()
@@ -30,9 +35,16 @@ class FavoritesViewModel @Inject constructor(
     private val _favoriteActivityIds = MutableStateFlow<List<String>>(emptyList())
     val favoriteActivityIds: StateFlow<List<String>> = _favoriteActivityIds.asStateFlow()
 
+    private val _favoriteHotelsIds = MutableStateFlow<List<String>>(emptyList())
+    val favoriteHotelsIds: StateFlow<List<String>> = _favoriteHotelsIds.asStateFlow()
+
     private var favoriteActivitiesSearchJob: Job? = null
 
+    private var favoriteHotelsSearchJob: Job? = null
+
     private val favoriteIdsSet: MutableSet<String> = mutableSetOf()
+
+    private val cityCache = mutableMapOf<String, String>()
 
     init {
         queryFavoriteActivities()
@@ -42,11 +54,30 @@ class FavoritesViewModel @Inject constructor(
         _uiState.update { it.copy(query = newQuery) }
     }
 
+    private suspend fun getCityName(lat: Double, lng: Double): String {
+        val key = "${lat},${lng}"
+        return cityCache[key] ?: run {
+            val cityName = getCityFromCoordinatesUseCase(lat, lng)
+            cityCache[key] = cityName
+            cityName
+        }
+    }
+
+    private suspend fun convertActivityWithCity(activity: FavoriteActivityEntity): FavoriteActivityEntity {
+        val cityName = getCityName(activity.latitude, activity.longitude)
+        return activity.copy(location = cityName)
+    }
+
+    private suspend fun convertHotelWithCity(hotel: FavoriteHotelEntity): FavoriteHotelEntity {
+        val cityName = getCityName(hotel.latitude, hotel.longitude)
+        return hotel.copy(address = cityName)
+    }
+
     fun queryFavoriteActivities() {
         favoriteActivitiesSearchJob?.cancel()
 
         favoriteActivitiesSearchJob = viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, destinations = emptyList()) }
+            _uiState.update { it.copy(isLoading = true, activities = emptyList()) }
 
             try {
                 val result = queryFavoriteActivitiesUseCase(_uiState.value.query)
@@ -63,8 +94,9 @@ class FavoritesViewModel @Inject constructor(
 
                 result.getOrNull()?.collect { activity ->
                     ensureActive()
-                    destinations.add(activity)
-                    _uiState.update { it.copy(destinations = destinations.toList()) }
+                    val activityWithCity = convertActivityWithCity(activity)
+                    destinations.add(activityWithCity)
+                    _uiState.update { it.copy(activities = destinations.toList()) }
                 }
 
                 val ids = destinations.map { it.id }
@@ -97,25 +129,45 @@ class FavoritesViewModel @Inject constructor(
         }
     }
 
-    fun toggleFavorite(activity: FavoriteActivityEntity) {
-        _uiState.update { it.copy(isFavoriteLoading = true) }
+    fun queryFavoriteHotels() {
+        favoriteHotelsSearchJob?.cancel()
+
+        favoriteHotelsSearchJob = viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, hotels = emptyList()) }
+
+            try {
+                val hotels = mutableListOf<FavoriteHotelEntity>()
+                val result = queryFavoriteHotelsUseCase(_uiState.value.query)
+
+                result.collect { hotel ->
+                    ensureActive()
+                    val hotelWithCity = convertHotelWithCity(hotel)
+                    hotels.add(hotelWithCity)
+                    _uiState.update { it.copy(hotels = hotels.toList()) }
+                }
+
+                val ids = hotels.map { it.id }
+                _favoriteHotelsIds.value = ids
+
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    _uiState.update { it.copy(error = e.localizedMessage ?: "Unknown error") }
+                }
+            } finally {
+                if (isActive) {
+                    _uiState.update { it.copy(isLoading = false) }
+                }
+            }
+        }
+    }
+
+    fun removeFavoriteHotel(hotelId: String) {
         viewModelScope.launch {
             try {
-                if (favoriteIdsSet.contains(activity.id)) {
-                    removeFavoriteActivityByIdUseCase(activity.id)
-                    favoriteIdsSet.remove(activity.id)
-                } else {
-                    val result = saveFavoriteActivityUseCase(activity)
-                    if (result.isFailure) {
-                        throw result.exceptionOrNull() ?: Exception("Unknown error saving favorite")
-                    }
-                    favoriteIdsSet.add(activity.id)
-                }
-                _favoriteActivityIds.value = favoriteIdsSet.toList()
+                val result = removeFavoriteHotelUseCase(hotelId)
+                queryFavoriteHotels()
             } catch (e: Exception) {
                 _uiState.update { it.copy(error = e.localizedMessage ?: "Unknown error") }
-            } finally {
-                _uiState.update { it.copy(isFavoriteLoading = false) }
             }
         }
     }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/HomeScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/HomeScreen.kt
@@ -20,38 +20,48 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
-import com.projectlab.booking.presentation.favorites.FavoritesViewModel
+import com.projectlab.booking.models.HotelUi
 import com.projectlab.booking.presentation.home.components.HomeSearchComponent
 import com.projectlab.booking.presentation.home.components.RecommendedActivitiesComponent
 import com.projectlab.booking.presentation.home.components.RecommendedHotelsComponent
 import com.projectlab.core.data.mapper.toFavoriteActivityEntity
 import com.projectlab.core.data.model.ActivityDto
+import com.projectlab.core.domain.model.Hotel
+import com.projectlab.core.domain.model.Location
 import com.projectlab.core.presentation.designsystem.component.BottomNavRoute
 import com.projectlab.core.presentation.designsystem.component.BottomNavigationBar
 import com.projectlab.core.presentation.designsystem.theme.spacing
 import com.projectlab.core.presentation.ui.viewmodel.LocationViewModel
+import kotlin.collections.set
 
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
     locationViewModel: LocationViewModel,
     homeViewModel: HomeViewModel,
-    favoritesViewModel: FavoritesViewModel,
     navController: NavController,
     onFavoritesClick: () -> Unit,
     onTripsClick: () -> Unit,
     onProfileClick: () -> Unit,
     onClickSearchHotel: () -> Unit,
-    onItemClick: (String) -> Unit,
+    onActivityItemClick: (String) -> Unit,
+    onHotelItemClick: (HotelUi) -> Unit,
 ) {
     val context = LocalContext.current
     val currentLocation = locationViewModel.location.value
     val uiState by homeViewModel.uiState.collectAsState()
-    val favoriteIds = favoritesViewModel.favoriteActivityIds.collectAsState().value
+    val favoriteActivityIds = homeViewModel.favoriteActivityIds.collectAsState().value
+    val favoriteHotelIds = homeViewModel.favoriteHotelsIds.collectAsState().value
+
+    var location by remember { mutableStateOf("") }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -72,7 +82,19 @@ fun HomeScreen(
     }
 
     LaunchedEffect(currentLocation) {
-        homeViewModel.fetchRecommendedActivities(currentLocation)
+        currentLocation?.let { location = locationViewModel.reverseGeocodeLocation(it) }
+    }
+
+    LaunchedEffect(currentLocation?.latitude, currentLocation?.longitude) {
+        if (currentLocation != null) {
+            homeViewModel.fetchRecommendedActivities(currentLocation)
+        }
+    }
+
+    LaunchedEffect(currentLocation?.latitude, currentLocation?.longitude) {
+        if (currentLocation != null) {
+        homeViewModel.fetchRecommendedHotels(currentLocation)
+            }
     }
 
     LaunchedEffect(Unit) {
@@ -86,7 +108,11 @@ fun HomeScreen(
     }
 
     LaunchedEffect(Unit) {
-        favoritesViewModel.queryFavoriteActivities()
+        homeViewModel.fetchFavoriteActivities()
+    }
+
+    LaunchedEffect(Unit) {
+        homeViewModel.fetchFavoriteHotels()
     }
 
     Scaffold(
@@ -111,12 +137,18 @@ fun HomeScreen(
                     },
                     onDeleteHistoryEntry = homeViewModel::onDeleteHistoryEntry,
                     onClickSearchHotel = { onClickSearchHotel() },
-                    location = locationViewModel.address.value,
-                    favoriteIds = favoriteIds,
-                    onActivityClick = onItemClick,
-                    onFavoritesToggle = { activity ->
-                        favoritesViewModel.toggleFavorite(activity.toFavoriteActivityEntity())
-                    }
+                    location = location,
+                    favoriteActivityIds = favoriteActivityIds,
+                    favoriteHotelIds = favoriteHotelIds,
+                    onActivityClick = onActivityItemClick,
+                    onHotelClick = onHotelItemClick,
+                    onActivityFavoritesToggle = { activity ->
+                        homeViewModel.toggleFavoriteActivity(activity.toFavoriteActivityEntity())
+                    },
+                    onHotelFavoritesToggle = { hotel ->
+                        homeViewModel.toggleFavoriteHotel(hotel)
+                    },
+                    reverseGeocode = { location -> locationViewModel.reverseGeocodeLocation(location) }
                 )
             }
     )
@@ -128,15 +160,36 @@ fun HomeScreenComponent(
     modifier: Modifier = Modifier,
     uiState: HomeUiState,
     location: String,
-    favoriteIds: List<String>,
+    favoriteActivityIds: List<String>,
+    favoriteHotelIds: List<String>,
     contentPadding: PaddingValues = PaddingValues(MaterialTheme.spacing.none),
     onQueryChange: (String) -> Unit,
     onQuerySubmitted: () -> Unit,
     onDeleteHistoryEntry: (String) -> Unit,
     onClickSearchHotel: () -> Unit,
     onActivityClick: (id: String) -> Unit,
-    onFavoritesToggle: (ActivityDto) -> Unit
+    onHotelClick: (HotelUi) -> Unit,
+    onActivityFavoritesToggle: (ActivityDto) -> Unit,
+    onHotelFavoritesToggle: (Hotel) -> Unit,
+    reverseGeocode: suspend (Location) -> String,
 ) {
+
+    val recommendedActivities = uiState.recommendedActivities
+    val cityMap = remember { mutableStateMapOf<String, String?>() }
+
+    LaunchedEffect(recommendedActivities) {
+        recommendedActivities.forEach { activity ->
+            if (!cityMap.containsKey(activity.id)) {
+                val location = Location(
+                    latitude = activity.geoCode.latitude,
+                    longitude = activity.geoCode.longitude
+                )
+                val city = reverseGeocode(location)
+                cityMap[activity.id] = city
+            }
+        }
+    }
+
 
     Column(
         modifier = modifier
@@ -153,7 +206,7 @@ fun HomeScreenComponent(
         )
         Spacer(modifier.height(MaterialTheme.spacing.semiHuge))
         Box(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
@@ -164,19 +217,18 @@ fun HomeScreenComponent(
 
                     RecommendedActivitiesComponent(
                         uiState = uiState,
-                        location = location,
-                        favoriteIds = favoriteIds,
-                        onFavoriteClick = onFavoritesToggle,
+                        cityMap = cityMap,
+                        favoriteIds = favoriteActivityIds,
+                        onFavoriteClick = onActivityFavoritesToggle,
                         onItemClick = onActivityClick
                     )
 
                     Spacer(modifier.height(MaterialTheme.spacing.semiHuge))
                     RecommendedHotelsComponent(
                         uiState = uiState,
-                        location = location,
-                        favoriteIds = favoriteIds,
-                        onFavoriteClick = onFavoritesToggle,
-                        onItemClick = onActivityClick
+                        favoriteIds = favoriteHotelIds,
+                        onFavoriteClick = onHotelFavoritesToggle,
+                        onItemClick = onHotelClick
                     )
                 }
             }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/HomeUiState.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/HomeUiState.kt
@@ -2,15 +2,18 @@ package com.projectlab.booking.presentation.home
 
 import com.projectlab.core.data.model.ActivityDto
 import com.projectlab.core.domain.entity.FavoriteActivityEntity
+import com.projectlab.core.domain.model.Hotel
 
 data class HomeUiState(
     val query: String = "",
     val activities: List<ActivityDto> = emptyList(),
     val recommendedActivities: List<ActivityDto> = emptyList(),
-    val recommendedHotels: List<ActivityDto> = emptyList(),
+    val recommendedHotels: List<Hotel> = emptyList(),
     val history: List<String> = emptyList(),
     val favoriteActivities: List<FavoriteActivityEntity> = emptyList(),
+    val favoriteHotels: List<Hotel> = emptyList(),
     val isLoading: Boolean = true,
     val error: String? = null,
-    val hasLoadedRecommendations: Boolean = false
+    val hasLoadedRecommendations: Boolean = false,
+    val isFavoriteLoading: Boolean
 )

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/HomeViewModel.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/HomeViewModel.kt
@@ -3,14 +3,22 @@ package com.projectlab.booking.presentation.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.projectlab.core.data.mapper.toDto
+import com.projectlab.core.domain.entity.FavoriteActivityEntity
+import com.projectlab.core.domain.model.Hotel
 import com.projectlab.core.domain.model.Location
 import com.projectlab.core.domain.proto.SearchHistory.HistoryType
 import com.projectlab.core.domain.repository.ActivityRepository
 import com.projectlab.core.domain.repository.SearchHistoryProvider
-import com.projectlab.core.domain.repository.UserSessionProvider
 import com.projectlab.core.domain.use_cases.activities.GetActivitiesUseCase
+import com.projectlab.core.domain.use_cases.activities.RemoveFavoriteActivityByIdUseCase
+import com.projectlab.core.domain.use_cases.activities.SaveFavoriteActivityUseCase
 import com.projectlab.core.domain.use_cases.error.ErrorMapper
+import com.projectlab.core.domain.use_cases.hotels.GetFavoriteHotelsUseCase
+import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCoordinatesUseCase
+import com.projectlab.core.domain.use_cases.hotels.RemoveFavoriteHotelUseCase
+import com.projectlab.core.domain.use_cases.hotels.SaveFavoriteHotelUseCase
 import com.projectlab.core.domain.use_cases.location.GetCoordinatesFromCityUseCase
+import com.projectlab.core.domain.util.DataError
 import com.projectlab.core.domain.util.Result
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -29,18 +37,34 @@ class HomeViewModel @Inject constructor(
     private val errorMapper: ErrorMapper,
     private val historyProvider: SearchHistoryProvider,
     private val getCoordinatesFromCityUseCase: GetCoordinatesFromCityUseCase,
+    private val getHotelsByCoordinatesUseCase: GetHotelsByCoordinatesUseCase,
+    private val saveFavoriteActivityUseCase: SaveFavoriteActivityUseCase,
+    private val saveFavoriteHotelUseCase: SaveFavoriteHotelUseCase,
+    private val removeFavoriteActivityByIdUseCase: RemoveFavoriteActivityByIdUseCase,
+    private val getFavoriteHotelsUseCase: GetFavoriteHotelsUseCase,
+    private val removeFavoriteHotelUseCase: RemoveFavoriteHotelUseCase,
     private val activityRepository: ActivityRepository,
     private val dispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(HomeUiState())
+    private val _uiState = MutableStateFlow(HomeUiState(isFavoriteLoading = true))
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     private val _navigationEvent = MutableSharedFlow<String>()
     val navigationEvent = _navigationEvent.asSharedFlow()
 
+    private val _favoriteActivityIds = MutableStateFlow<List<String>>(emptyList())
+    val favoriteActivityIds: StateFlow<List<String>> = _favoriteActivityIds.asStateFlow()
+
+    private val _favoriteHotelsIds = MutableStateFlow<List<String>>(emptyList())
+    val favoriteHotelsIds: StateFlow<List<String>> = _favoriteHotelsIds.asStateFlow()
+
+    private val favoriteActivitiesIdsSet: MutableSet<String> = mutableSetOf()
+
+    private val favoriteHotelsIdsSet: MutableSet<String> = mutableSetOf()
+
     fun fetchSearchHistory() {
-        viewModelScope.launch (dispatcher){
+        viewModelScope.launch(dispatcher) {
             val list = historyProvider.getSearchHistory(HistoryType.ACTIVITY)
             _uiState.update { it.copy(history = list.reversed()) }
         }
@@ -86,8 +110,8 @@ class HomeViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
 
             val parisCoordinates = getCoordinatesFromCityUseCase("Paris") ?: (48.8566 to 2.3522)
-
-            val initialCoordinates = location?.let { it.latitude to it.longitude } ?: parisCoordinates
+            val initialCoordinates =
+                location?.let { it.latitude to it.longitude } ?: parisCoordinates
 
             var result = getActivitiesUseCase(initialCoordinates.first, initialCoordinates.second)
 
@@ -121,11 +145,127 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun fetchRecommendedHotels(location: Location?) {
+        viewModelScope.launch {
+
+            _uiState.update { it.copy(isLoading = true) }
+
+            val parisCoordinates = getCoordinatesFromCityUseCase("Paris") ?: (48.8566 to 2.3522)
+
+            val initialCoordinates =
+                location?.let { it.latitude to it.longitude } ?: parisCoordinates
+
+            var result =
+                getHotelsByCoordinatesUseCase(
+                    initialCoordinates.first, initialCoordinates.second, emptyList(), emptyList()
+                )
+
+            if (location != null && result is Result.Success && result.data.isEmpty()) {
+                result =
+                    getHotelsByCoordinatesUseCase(
+                        parisCoordinates.first,
+                        parisCoordinates.second,
+                        emptyList(),
+                        emptyList()
+                    )
+            }
+
+            when (result) {
+                is Result.Success -> {
+                    val filtered = result.data
+                        .take(10)
+
+                    _uiState.update {
+                        it.copy(
+                            recommendedHotels = filtered,
+                            hasLoadedRecommendations = true
+                        )
+                    }
+
+                    fetchFavoriteHotels()
+                }
+
+                is Result.Error -> {
+                    _uiState.update { it.copy(error = errorMapper.map(result.error as DataError.Network)) }
+                }
+            }
+
+            _uiState.update { it.copy(isLoading = false) }
+        }
+    }
+
     fun fetchFavoriteActivities() {
         viewModelScope.launch {
-                activityRepository.getFavoriteActivities().collect { favorites ->
-                    _uiState.update { it.copy(favoriteActivities = favorites) }
+            activityRepository.getFavoriteActivities().collect { favorites ->
+                _uiState.update { it.copy(favoriteActivities = favorites) }
+
+                val favoriteIds = favorites.map { it.id }
+                _favoriteActivityIds.value = favoriteIds
+
+                favoriteActivitiesIdsSet.clear()
+                favoriteActivitiesIdsSet.addAll(favoriteIds)
+            }
+        }
+    }
+
+    fun fetchFavoriteHotels() {
+        viewModelScope.launch {
+            try {
+                getFavoriteHotelsUseCase().collect { favorites ->
+                    _uiState.update { it.copy(favoriteHotels = favorites) }
+
+                    val favoriteIds = favorites.map { it.id }
+                    _favoriteHotelsIds.value = favoriteIds
+
+                    favoriteHotelsIdsSet.clear()
+                    favoriteHotelsIdsSet.addAll(favoriteIds)
                 }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.localizedMessage ?: "Unknown error") }
+            }
+        }
+    }
+
+    fun toggleFavoriteActivity(activity: FavoriteActivityEntity) {
+        _uiState.update { it.copy(isFavoriteLoading = true) }
+        viewModelScope.launch {
+            try {
+                if (favoriteActivitiesIdsSet.contains(activity.id)) {
+                    removeFavoriteActivityByIdUseCase(activity.id)
+                    favoriteActivitiesIdsSet.remove(activity.id)
+                } else {
+                    val result = saveFavoriteActivityUseCase(activity)
+                    if (result.isFailure) {
+                        throw result.exceptionOrNull() ?: Exception("Unknown error saving favorite")
+                    }
+                    favoriteActivitiesIdsSet.add(activity.id)
+                }
+                _favoriteActivityIds.value = favoriteActivitiesIdsSet.toList()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.localizedMessage ?: "Unknown error") }
+            } finally {
+                _uiState.update { it.copy(isFavoriteLoading = false) }
+            }
+        }
+    }
+
+    fun toggleFavoriteHotel(hotel: Hotel) {
+        _uiState.update { it.copy(isFavoriteLoading = true) }
+        viewModelScope.launch {
+            try {
+                if (favoriteHotelsIdsSet.contains(hotel.id)) {
+                    val result = removeFavoriteHotelUseCase(hotel.id)
+                    favoriteHotelsIdsSet.remove(hotel.id)
+                } else {
+                    val result = saveFavoriteHotelUseCase(hotel)
+                    favoriteHotelsIdsSet.add(hotel.id)
+                }
+                _favoriteHotelsIds.value = favoriteHotelsIdsSet.toList()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.localizedMessage ?: "Unknown error") }
+            } finally {
+                _uiState.update { it.copy(isFavoriteLoading = false) }
+            }
         }
     }
 }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/components/RecommendedActivitiesComponent.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/components/RecommendedActivitiesComponent.kt
@@ -25,7 +25,7 @@ import com.projectlab.core.presentation.designsystem.theme.spacing
 fun RecommendedActivitiesComponent(
     modifier: Modifier = Modifier,
     uiState: HomeUiState,
-    location: String,
+    cityMap: Map<String, String?>,
     favoriteIds: List<String>,
     onFavoriteClick: (ActivityDto) -> Unit,
     onItemClick: (String) -> Unit
@@ -36,7 +36,7 @@ fun RecommendedActivitiesComponent(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.ElementSpacing)
         ) {
             Text(
-                text = stringResource(R.string.recommended_activities_near_you),
+                text = stringResource(R.string.recommended_activities),
                 fontSize = 18.sp,
                 fontWeight = FontWeight.W600,
                 color = MaterialTheme.colorScheme.onBackground
@@ -47,6 +47,7 @@ fun RecommendedActivitiesComponent(
             ) {
                 items(uiState.recommendedActivities) { activity ->
                     val isFavorite = favoriteIds.contains(activity.id)
+                    val locationLabel = cityMap[activity.id] ?: ""
                     VerticalFavoriteCard(
                         name = activity.name,
                         description = if (activity.description.isNotEmpty()) {
@@ -54,8 +55,8 @@ fun RecommendedActivitiesComponent(
                         } else {
                             stringResource(R.string.no_description)
                         },
-                        location = location,
-                        rating = activity.rating,
+                        location = locationLabel,
+                        rating = activity.rating.toString(),
                         pictureUrl = activity.pictures.firstOrNull() ?: "",
                         onFavoriteClick = { onFavoriteClick(activity) },
                         isFavorite = isFavorite,

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/components/RecommendedHotelsComponent.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/home/components/RecommendedHotelsComponent.kt
@@ -15,9 +15,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.projectlab.booking.models.HotelUi
+import com.projectlab.booking.models.toHotelUi
 import com.projectlab.booking.presentation.R
 import com.projectlab.booking.presentation.home.HomeUiState
-import com.projectlab.core.data.model.ActivityDto
+import com.projectlab.core.domain.model.Hotel
 import com.projectlab.core.presentation.designsystem.component.VerticalFavoriteCard
 import com.projectlab.core.presentation.designsystem.theme.spacing
 
@@ -25,10 +27,9 @@ import com.projectlab.core.presentation.designsystem.theme.spacing
 fun RecommendedHotelsComponent(
     modifier: Modifier = Modifier,
     uiState: HomeUiState,
-    location: String,
     favoriteIds: List<String>,
-    onFavoriteClick: (ActivityDto) -> Unit,
-    onItemClick: (String) -> Unit
+    onFavoriteClick: (Hotel) -> Unit,
+    onItemClick: (HotelUi) -> Unit
 ) {
     if (!uiState.isLoading) {
         Column(
@@ -36,31 +37,27 @@ fun RecommendedHotelsComponent(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.ElementSpacing)
         ) {
             Text(
-                text = stringResource(R.string.recommended_hotels_near_you),
+                text = stringResource(R.string.recommended_hotels),
                 fontSize = 18.sp,
                 fontWeight = FontWeight.W600,
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
-            if (uiState.recommendedActivities.isNotEmpty()) {
+            if (uiState.recommendedHotels.isNotEmpty()) {
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.ElementSpacing),
                 ) {
-                    items(uiState.recommendedActivities) { activity ->
-                        val isFavorite = favoriteIds.contains(activity.id)
+                    items(uiState.recommendedHotels) { hotel ->
+                        val isFavorite = favoriteIds.contains(hotel.id)
                         VerticalFavoriteCard(
-                            name = activity.name,
-                            description = if (activity.description.isNotEmpty()) {
-                                activity.description
-                            } else {
-                                stringResource(R.string.no_description)
-                            },
-                            location = location,
-                            rating = activity.rating,
-                            pictureUrl = activity.pictures.firstOrNull() ?: "",
-                            onFavoriteClick = { onFavoriteClick(activity) },
+                            name = hotel.name,
+                            description = hotel.amenities.toString(),
+                            location = hotel.location.address,
+                            rating = hotel.rating.overallRating.toString(),
+                            pictureUrl = hotel.displayImageUrl,
+                            onFavoriteClick = {onFavoriteClick(hotel)},
                             isFavorite = isFavorite,
-                            onClick = { onItemClick(activity.id) },
+                            onClick = { onItemClick(hotel.toHotelUi()) },
                             modifier = Modifier.width(MaterialTheme.spacing.recommendedCardWidth)
                         )
                     }

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/search/activities/SearchActivityScreen.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/search/activities/SearchActivityScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import com.projectlab.booking.presentation.favorites.FavoritesViewModel
 import com.projectlab.core.data.mapper.toFavoriteActivityEntity
 import com.projectlab.core.data.model.ActivityDto
 import com.projectlab.core.domain.model.Location
@@ -55,6 +56,7 @@ fun SearchActivityScreen(
     modifier: Modifier = Modifier,
     locationViewModel: LocationViewModel,
     searchActivityViewModel: SearchActivityViewModel,
+    favoritesViewModel: FavoritesViewModel,
     initialQuery: String,
     onActivityClick: (String) -> Unit,
     onBackClick: () -> Unit,
@@ -63,7 +65,7 @@ fun SearchActivityScreen(
     val address by locationViewModel.address
     val currentLocation = locationViewModel.location.value
     val uiState by searchActivityViewModel.uiState.collectAsState()
-    val favoriteIds = searchActivityViewModel.favoriteActivityIds.collectAsState().value
+    val favoriteIds by favoritesViewModel.favoriteActivityIds.collectAsState()
 
     // As soon as the Composable is mounted, start the search
     LaunchedEffect(initialQuery) {
@@ -91,7 +93,7 @@ fun SearchActivityScreen(
     }
 
     LaunchedEffect(Unit) {
-        searchActivityViewModel.fetchFavoriteActivities()
+        favoritesViewModel.queryFavoriteActivities()
     }
 
     /**
@@ -119,7 +121,7 @@ fun SearchActivityScreen(
     }
 
     val onFavoriteToggle: (ActivityDto) -> Unit = { activity ->
-        searchActivityViewModel.toggleFavoriteActivity(activity.toFavoriteActivityEntity())
+        favoritesViewModel.toggleFavoriteActivity(activity.toFavoriteActivityEntity())
     }
 
     Column(
@@ -204,7 +206,7 @@ fun SearchActivityResultsComponent(
         }
     }
 
-    if (uiState.isLoading) {
+    if (uiState.isLoading ) {
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
@@ -236,7 +238,7 @@ fun SearchActivityResultsComponent(
                     activity = activity,
                     modifier = Modifier.fillMaxWidth(),
                     city = city,
-                    onPress = {onPress},
+                    onPress = {onPress(activity.id)},
                     isFavorite = isFavorite,
                     onFavoriteToggle = {onFavoriteToggle(activity)}
                 )

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/search/activities/SearchActivityUiState.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/search/activities/SearchActivityUiState.kt
@@ -1,6 +1,7 @@
 package com.projectlab.booking.presentation.search.activities
 
 import com.projectlab.core.data.model.ActivityDto
+import com.projectlab.core.domain.entity.FavoriteActivityEntity
 
 enum class SearchOrigin {
     QUERY,
@@ -14,6 +15,8 @@ data class SearchActivityUiState(
     val error: String? = null,
     val showAllResults: Boolean = false,
     val address: String? = null,
+    val isFavoriteLoading: Boolean = false,
+    val favoriteActivities: List<FavoriteActivityEntity> = emptyList(),
     val history: List<String> = emptyList(),
     val searchOrigin: SearchOrigin = SearchOrigin.QUERY
 )

--- a/booking/presentation/src/main/java/com/projectlab/booking/presentation/search/hotels/components/SearchHotelContent.kt
+++ b/booking/presentation/src/main/java/com/projectlab/booking/presentation/search/hotels/components/SearchHotelContent.kt
@@ -61,7 +61,7 @@ fun SearchHotelsResultsComponent(
                     hotelUi = it.toHotelUi(),
                     onClickDetail = { navController.navigate("hotelDetail/${it.id}") },
                     onClickFavorite = { viewModel.unfavoriteHotel(it.id) },
-                    onClickUnfavorite = { viewModel.favoriteHotel(it.id) },
+                    onClickUnfavorite = { viewModel.favoriteHotel(it) },
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/booking/presentation/src/main/res/values-es/strings.xml
+++ b/booking/presentation/src/main/res/values-es/strings.xml
@@ -8,12 +8,12 @@
     <string name="hotels">Hoteles</string>
     <string name="favorites">Favoritos</string>
     <string name="no_description">Sumérgete en una experiencia única y descubre lo inesperado. Esta actividad ha sido seleccionada cuidadosamente para brindarte momentos memorables, aunque actualmente no cuenta con una descripción detallada. Prepárate para explorar, disfrutar y dejarte sorprender por lo que te espera. Ya sea que busques aventura, relajación o cultura, esta propuesta tiene todo el potencial para convertirse en una de tus favoritas.</string>
-    <string name="recommended_activities_near_you">Actividades recomendadas cerca de ti</string>
-    <string name="recommended_hotels_near_you">Hoteles recomendados cerca de ti</string>
+    <string name="recommended_hotels">Hoteles recomendados</string>
     <string name="successfully_booked">Reserva exitosa</string>
     <string name="travelin_logo_white">Travelin logo en blanco</string>
     <string name="price_per_night">%1$s /por noche</string>
     <string name="book_now">Reserva ahora!</string>
     <string name="amenities">Facilidades</string>
+    <string name="recommended_activities">Actividades recomendadas</string>
 
 </resources>

--- a/booking/presentation/src/main/res/values/strings.xml
+++ b/booking/presentation/src/main/res/values/strings.xml
@@ -8,8 +8,8 @@
     <string name="hotels">Hotels</string>
     <string name="favorites">Favorites</string>
     <string name="no_description">Dive into a unique experience and embrace the unexpected. While this activity doesn\'t currently have a detailed description, it has been carefully selected to offer you memorable moments. Get ready to explore, enjoy, and be surprised by what awaits. Whether you\'re looking for adventure, relaxation, or culture, this activity has the potential to become one of your favorites.</string>
-    <string name="recommended_activities_near_you">Recommended activities near you</string>
-    <string name="recommended_hotels_near_you">Recommended hotels near you</string>
+    <string name="recommended_activities">Recommended activities</string>
+    <string name="recommended_hotels">Recommended hotels</string>
     <string name="successfully_booked">Successfully booked</string>
     <string name="travelin_logo_white">Travelin logo in white</string>
     <string name="price_per_night">%1$s /per night</string>

--- a/core/data/src/main/java/com/projectlab/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/projectlab/core/data/di/DataModule.kt
@@ -5,10 +5,8 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.projectlab.core.data.Constants.REFERENCE_USERS
-import com.projectlab.core.data.repository.ActivityRepositoryImpl
 import com.projectlab.core.data.repository.AmadeusTokenProviderImpl
 import com.projectlab.core.data.repository.FlightRepositoryImpl
-import com.projectlab.core.data.repository.HotelsRepositoryImpl
 import com.projectlab.core.data.repository.ItineraryRepositoryImpl
 import com.projectlab.core.database.services.FirestoreActivityImpl
 import com.projectlab.core.database.services.FirestoreFlightImpl
@@ -27,9 +25,7 @@ import com.projectlab.core.domain.repository.OnboardingFlagProvider
 import com.projectlab.core.domain.repository.SearchHistoryProvider
 import com.projectlab.core.domain.repository.TokenProvider
 import com.projectlab.core.database.services.FirestoreUser
-import com.projectlab.core.domain.repository.ActivityRepository
 import com.projectlab.core.domain.repository.FlightRepository
-import com.projectlab.core.domain.repository.HotelsRepository
 import com.projectlab.core.domain.repository.ItineraryRepository
 import com.projectlab.core.domain.repository.UserSessionProvider
 import com.projectlab.core.domain.repository.UsersRepository

--- a/core/data/src/main/java/com/projectlab/core/data/di/HotelsBindingModule.kt
+++ b/core/data/src/main/java/com/projectlab/core/data/di/HotelsBindingModule.kt
@@ -1,0 +1,19 @@
+package com.projectlab.core.data.di
+
+import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCoordinatesUseCase
+import com.projectlab.core.domain.use_cases.hotels.GetHotelsByCoordinatesUseCaseImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class HotelsBindingModule {
+
+    @Binds
+    abstract fun GetHotelsByCoordinatesUseCase(
+        impl: GetHotelsByCoordinatesUseCaseImpl
+    ): GetHotelsByCoordinatesUseCase
+
+}

--- a/core/data/src/main/java/com/projectlab/core/data/usecase/GetFavoriteHotelsUseCaseImpl.kt
+++ b/core/data/src/main/java/com/projectlab/core/data/usecase/GetFavoriteHotelsUseCaseImpl.kt
@@ -1,0 +1,18 @@
+package com.projectlab.core.data.usecase
+
+import com.projectlab.core.domain.mapper.toHotel
+import com.projectlab.core.domain.model.Hotel
+import com.projectlab.core.domain.repository.HotelsRepository
+import com.projectlab.core.domain.use_cases.hotels.GetFavoriteHotelsUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetFavoriteHotelsUseCaseImpl @Inject constructor(
+    private val repository: HotelsRepository
+) : GetFavoriteHotelsUseCase {
+    override operator fun invoke(): Flow<List<Hotel>> {
+        return repository.getFavoriteHotels()
+            .map { hotels -> hotels.map { it.toHotel() } }
+    }
+}

--- a/core/data/src/main/java/com/projectlab/core/data/usecase/RemoveFavoriteUseCaseImpl.kt
+++ b/core/data/src/main/java/com/projectlab/core/data/usecase/RemoveFavoriteUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.projectlab.core.data.usecase
+
+import com.projectlab.core.domain.repository.HotelsRepository
+import com.projectlab.core.domain.use_cases.hotels.RemoveFavoriteHotelUseCase
+import com.projectlab.core.domain.util.DataError
+import com.projectlab.core.domain.util.Result
+import javax.inject.Inject
+
+class RemoveFavoriteHotelUseCaseImpl @Inject constructor(
+    private val repository: HotelsRepository
+) : RemoveFavoriteHotelUseCase {
+    override suspend operator fun invoke(hotelId: String): Result<Unit, DataError.Network> {
+        return repository.removeFavoriteHotelById(hotelId)
+    }
+}

--- a/core/data/src/main/java/com/projectlab/core/data/usecase/SaveFavoriteHotelUseCaseImpl.kt
+++ b/core/data/src/main/java/com/projectlab/core/data/usecase/SaveFavoriteHotelUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.projectlab.core.data.usecase
+
+import com.projectlab.core.domain.mapper.toFavoriteHotelEntity
+import com.projectlab.core.domain.model.Hotel
+import com.projectlab.core.domain.repository.HotelsRepository
+import com.projectlab.core.domain.use_cases.hotels.SaveFavoriteHotelUseCase
+import com.projectlab.core.domain.util.DataError
+import com.projectlab.core.domain.util.Result
+import javax.inject.Inject
+
+class SaveFavoriteHotelUseCaseImpl @Inject constructor(
+    private val repository: HotelsRepository
+) : SaveFavoriteHotelUseCase {
+    override suspend operator fun invoke(hotel: Hotel): Result<Unit, DataError> {
+        return repository.saveFavoriteHotel(hotel.toFavoriteHotelEntity())
+    }
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/entity/FavoriteHotelEntity.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/entity/FavoriteHotelEntity.kt
@@ -1,0 +1,16 @@
+package com.projectlab.core.domain.entity
+
+data class FavoriteHotelEntity(
+    val id: String = "",
+    val name: String = "",
+    val description: String = "",
+    val location: String = "",
+    val rating: Double = 0.0,
+    val displayImageUrl: String = "",
+    val amenities: List<String> = emptyList(),
+    val address: String = "",
+    val priceRange: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/core/domain/src/main/java/com/projectlab/core/domain/mapper/HotelMapper.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/mapper/HotelMapper.kt
@@ -1,0 +1,36 @@
+package com.projectlab.core.domain.mapper
+
+import com.projectlab.core.domain.entity.FavoriteHotelEntity
+import com.projectlab.core.domain.model.Hotel
+import com.projectlab.core.domain.model.HotelLocation
+import com.projectlab.core.domain.model.HotelRating
+
+fun Hotel.toFavoriteHotelEntity(): FavoriteHotelEntity {
+    return FavoriteHotelEntity(
+        id = this.id,
+        name = this.name,
+        description = "",
+        location = this.location.toString(),
+        rating = this.rating.overallRating.toDouble(),
+        displayImageUrl = this.displayImageUrl,
+        amenities = this.amenities ?: emptyList(),
+        address = this.location.toString(),
+        priceRange = this.displayPrice,
+        latitude = this.location.latitude,
+        longitude = this.location.longitude
+    )
+}
+
+fun FavoriteHotelEntity.toHotel(): Hotel {
+    return Hotel(
+        id = this.id,
+        name = this.name,
+        location = HotelLocation(this.longitude, this.latitude, "", "", this.location),
+        rating = HotelRating(0, this.rating.toInt(), 0),
+        displayImageUrl = this.displayImageUrl,
+        amenities = this.amenities,
+        displayPrice = this.priceRange,
+        phoneNumber = "",
+        hotelOffers = null,
+    )
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/model/Location.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/model/Location.kt
@@ -1,8 +1,28 @@
 package com.projectlab.core.domain.model
 
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
 data class Location(
     var latitude: Double,
     var longitude: Double,
     val city: String? = null,
     val country: String? = null
-)
+){
+    fun distanceTo(other: Location): Float {
+        val latDistance = Math.toRadians(other.latitude - latitude)
+        val longDistance = Math.toRadians(other.longitude - longitude)
+        val a = sin(latDistance / 2) * sin(latDistance / 2) +
+                cos(Math.toRadians(latitude)) * cos(Math.toRadians(other.latitude)) *
+                sin(longDistance / 2) * sin(longDistance / 2)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+        return EARTH_RADIUS_METERS * c.toFloat()
+    }
+
+    companion object {
+        private const val EARTH_RADIUS_METERS = 6_371_000
+    }
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/repository/HotelsRepository.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/repository/HotelsRepository.kt
@@ -1,9 +1,9 @@
 package com.projectlab.core.domain.repository
 
+import com.projectlab.core.domain.entity.FavoriteHotelEntity
 import com.projectlab.core.domain.entity.HotelEntity
 import com.projectlab.core.domain.model.EntityId
 import com.projectlab.core.domain.model.Hotel
-import com.projectlab.core.domain.model.Response
 import com.projectlab.core.domain.util.DataError
 import com.projectlab.core.domain.util.Result
 import kotlinx.coroutines.flow.Flow
@@ -41,6 +41,17 @@ interface HotelsRepository {
         ratings: String
     ): Result<List<Hotel>, DataError.Network>
 
-    suspend fun favoriteHotel(hotelId: String): Result<Boolean, DataError.Network>
+
+    suspend fun favoriteHotel(hotel: Hotel): Result<Boolean, DataError.Network>
     suspend fun unfavoriteHotel(hotelId: String): Result<Boolean, DataError.Network>
+
+    fun getFavoriteHotels(): Flow<List<FavoriteHotelEntity>>
+    fun queryFavoriteHotels(
+        nameQuery: String? = null,
+    ): Flow<FavoriteHotelEntity>
+    suspend fun saveFavoriteHotel(hotel: FavoriteHotelEntity): Result<Unit, DataError.Network>
+    suspend fun removeFavoriteHotelById(hotelId: String): Result<Unit, DataError.Network>
+    suspend fun isFavoriteHotel(hotelId: String): Result<Boolean, DataError.Network>
+
 }
+

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/FavoriteHotelUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/FavoriteHotelUseCase.kt
@@ -1,11 +1,12 @@
 package com.projectlab.core.domain.use_cases.hotels
 
+import com.projectlab.core.domain.model.Hotel
 import com.projectlab.core.domain.repository.HotelsRepository
 import javax.inject.Inject
 
 class FavoriteHotelUseCase @Inject constructor(
     private val repository: HotelsRepository
 ) {
-    suspend operator fun invoke(userId: String, hotelId: String) =
-        repository.favoriteHotel(hotelId)
+    suspend operator fun invoke(userId: String, hotel: Hotel) =
+        repository.favoriteHotel(hotel)
 }

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetFavoriteHotelsUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetFavoriteHotelsUseCase.kt
@@ -1,0 +1,8 @@
+package com.projectlab.core.domain.use_cases.hotels
+
+import com.projectlab.core.domain.model.Hotel
+import kotlinx.coroutines.flow.Flow
+
+fun interface GetFavoriteHotelsUseCase {
+    operator fun invoke(): Flow<List<Hotel>>
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetHotelsByCityUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetHotelsByCityUseCase.kt
@@ -11,5 +11,4 @@ class GetHotelsByCityUseCase @Inject constructor(private val repository: HotelsR
         amenities: List<String> = emptyList(),
         ratings: List<String> = emptyList()
     ) = repository.getHotelsByCity(cityCode, amenities.toString(), ratings.toString())
-
 }

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetHotelsByCoordinatesUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetHotelsByCoordinatesUseCase.kt
@@ -1,14 +1,14 @@
 package com.projectlab.core.domain.use_cases.hotels
 
-import com.projectlab.core.domain.repository.HotelsRepository
-import javax.inject.Inject
+import com.projectlab.core.domain.model.Hotel
+import com.projectlab.core.domain.util.DataError
+import com.projectlab.core.domain.util.Result
 
-class GetHotelsByCoordinatesUseCase @Inject constructor(private val repository: HotelsRepository){
-
+fun interface GetHotelsByCoordinatesUseCase {
     suspend operator fun invoke(
         latitude: Double,
         longitude: Double,
-        amenities: List<String> = emptyList(),
-        ratings: List<String> = emptyList()
-    ) = repository.getHotelsByCoordinates(latitude, longitude, amenities.toString(), ratings.toString())
+        amenities: List<String>,
+        ratings: List<String>
+    ): Result<List<Hotel>, DataError>
 }

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetHotelsByCoordinatesUseCaseImpl.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/GetHotelsByCoordinatesUseCaseImpl.kt
@@ -1,0 +1,21 @@
+package com.projectlab.core.domain.use_cases.hotels
+
+import com.projectlab.core.domain.repository.HotelsRepository
+import javax.inject.Inject
+
+class GetHotelsByCoordinatesUseCaseImpl @Inject constructor(
+    private val repository: HotelsRepository
+) : GetHotelsByCoordinatesUseCase {
+
+    override suspend operator fun invoke(
+        latitude: Double,
+        longitude: Double,
+        amenities: List<String>,
+        ratings: List<String>
+    ) = repository.getHotelsByCoordinates(
+        latitude,
+        longitude,
+        amenities.toString(),
+        ratings.toString()
+    )
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/HotelsUseCases.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/HotelsUseCases.kt
@@ -5,7 +5,9 @@ data class HotelsUseCases(
     val getHotelsByCity: GetHotelsByCityUseCase,
     val getHotelsByCoordinates: GetHotelsByCoordinatesUseCase,
     val favoriteHotel: FavoriteHotelUseCase,
-    val unfavoriteHotel: UnfavoriteHotelUseCase
-
+    val unfavoriteHotel: UnfavoriteHotelUseCase,
+    val saveFavoriteHotelUseCase: SaveFavoriteHotelUseCase,
+    val getFavoriteHotelsUseCase: GetFavoriteHotelsUseCase,
+    val removeFavoriteHotelUseCase: RemoveFavoriteHotelUseCase,
 )
 

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/QueryFavoriteHotelsUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/QueryFavoriteHotelsUseCase.kt
@@ -1,0 +1,14 @@
+package com.projectlab.core.domain.use_cases.hotels
+
+import com.projectlab.core.domain.entity.FavoriteHotelEntity
+import com.projectlab.core.domain.repository.HotelsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class QueryFavoriteHotelsUseCase @Inject constructor(
+    private val repository: HotelsRepository
+) {
+    operator fun invoke(query: String): Flow<FavoriteHotelEntity> {
+        return repository.queryFavoriteHotels(query)
+    }
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/RemoveFavoriteHotelUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/RemoveFavoriteHotelUseCase.kt
@@ -1,0 +1,8 @@
+package com.projectlab.core.domain.use_cases.hotels
+
+import com.projectlab.core.domain.util.DataError
+import com.projectlab.core.domain.util.Result
+
+fun interface RemoveFavoriteHotelUseCase {
+    suspend operator fun invoke(hotelId: String): Result<Unit, DataError.Network>
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/SaveFavoriteHotelUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/SaveFavoriteHotelUseCase.kt
@@ -1,0 +1,9 @@
+package com.projectlab.core.domain.use_cases.hotels
+
+import com.projectlab.core.domain.model.Hotel
+import com.projectlab.core.domain.util.DataError
+import com.projectlab.core.domain.util.Result
+
+fun interface SaveFavoriteHotelUseCase {
+    suspend operator fun invoke(hotel: Hotel): Result<Unit, DataError>
+}

--- a/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/UnfavoriteHotelUseCase.kt
+++ b/core/domain/src/main/java/com/projectlab/core/domain/use_cases/hotels/UnfavoriteHotelUseCase.kt
@@ -6,6 +6,6 @@ import javax.inject.Inject
 class UnfavoriteHotelUseCase @Inject constructor(
     private val repository: HotelsRepository
 ) {
-    suspend operator fun invoke(userId: String, hotelId: String) =
+    suspend operator fun invoke(hotelId: String) =
         repository.unfavoriteHotel(hotelId)
 }

--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/BottomNavigationBar.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/BottomNavigationBar.kt
@@ -68,7 +68,6 @@ fun BottomNavigationBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(MaterialTheme.spacing.BottomBarHeight)
                 .background(MaterialTheme.colorScheme.background),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically,
@@ -111,7 +110,8 @@ fun BottomNavItem(
     Column(
         modifier = Modifier
             .clickable(onClick = onClick)
-            .padding(vertical = MaterialTheme.spacing.SmallSpacing),
+            .padding(vertical = MaterialTheme.spacing.SmallSpacing)
+            .navigationBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(

--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/StarRatingBar.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/StarRatingBar.kt
@@ -14,9 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.projectlab.core.presentation.designsystem.R
 import com.projectlab.core.presentation.designsystem.theme.gold
 import com.projectlab.core.presentation.designsystem.theme.spacing
@@ -24,7 +22,7 @@ import kotlin.math.ceil
 
 @Composable
 fun StarRatingBar(
-    rating: Float,
+    rating: String,
     modifier: Modifier = Modifier,
     starSize: Dp = MaterialTheme.spacing.ElementSpacing,
     spaceBetween: Dp = MaterialTheme.spacing.extraSmall,
@@ -35,6 +33,7 @@ fun StarRatingBar(
     val star = painterResource(R.drawable.star_24px)
     val starHalf = painterResource(R.drawable.star_half_24px)
     val starFull = painterResource(R.drawable.star_full_24px)
+    val ratingFloat = rating.toFloatOrNull() ?: 0f
 
     Row(
         modifier = modifier.selectableGroup(),
@@ -42,8 +41,8 @@ fun StarRatingBar(
     ) {
         for (i in 1..maxStars) {
             val icon = when {
-                i <= rating -> starFull
-                i == ceil(rating).toInt() -> starHalf
+                i <= ratingFloat -> starFull
+                i == ceil(ratingFloat).toInt() -> starHalf
                 else -> star
             }
 
@@ -63,7 +62,7 @@ fun StarRatingBar(
             Spacer(modifier = Modifier.width(MaterialTheme.spacing.small))
 
             Text(
-                text = if (rating > 0) {
+                text = if (ratingFloat > 0) {
                     rating.toString()
                 } else {
                     stringResource(R.string.tour_list_card_no_reviews)
@@ -74,15 +73,4 @@ fun StarRatingBar(
             )
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun StarRatingBarPreview() {
-    StarRatingBar(
-        rating = 3.2f,
-        starSize = 16.dp,
-        spaceBetween = 0.dp,
-        textColor = Color.Black,
-    )
 }

--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/TourCardHeader.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/TourCardHeader.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import com.projectlab.core.data.model.ActivityDto
 import com.projectlab.core.presentation.designsystem.R
@@ -37,7 +36,6 @@ import com.projectlab.core.presentation.designsystem.theme.spacing
 fun TourCardHeader(
     modifier: Modifier = Modifier,
     activity: ActivityDto,
-    navController: NavController,
     isFavorite: Boolean,
     isFavoriteLoading: Boolean,
     onFavoriteClick: () -> Unit,
@@ -137,7 +135,7 @@ fun TourCardHeader(
 
                     Spacer(modifier = Modifier.height(10.dp))
 
-                    StarRatingBar(rating = activity.rating, textColor = Color.White)
+                    StarRatingBar(rating = activity.rating.toString(), textColor = Color.White)
                 }
             }
         }

--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/TourListCard.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/TourListCard.kt
@@ -70,7 +70,7 @@ fun TourListCard(
             TourName(modifier = Modifier, activity.name)
             StarRatingBar(
                 maxStars = 5,
-                rating = activity.rating,
+                rating = activity.rating.toString(),
                 textColor = Color.Black
             )
             TourCity(city)

--- a/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/VerticalFavoriteCard.kt
+++ b/core/presentation/designsystem/src/main/java/com/projectlab/core/presentation/designsystem/component/VerticalFavoriteCard.kt
@@ -37,7 +37,7 @@ fun VerticalFavoriteCard(
     name: String,
     description: String,
     location: String,
-    rating: Float,
+    rating: String,
     pictureUrl: String?,
     isFavorite: Boolean,
     onFavoriteClick: () -> Unit,

--- a/core/presentation/designsystem/src/main/res/values-es/strings.xml
+++ b/core/presentation/designsystem/src/main/res/values-es/strings.xml
@@ -70,5 +70,6 @@
     <string name="details">Detalles</string>
     <string name="hotel">Hotel</string>
     <string name="sqm">%1$s sqm</string>
+    <string name="no_results_found">No hay resultados para esa ubicación. Por favor intenta con otra ciudad.</string>
 
 </resources>

--- a/core/presentation/designsystem/src/main/res/values/mapbox_access_token.xml
+++ b/core/presentation/designsystem/src/main/res/values/mapbox_access_token.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="mapbox_access_token" translatable="false" tools:ignore="UnusedResources">TOKEN</string>
+    <string name="mapbox_access_token" translatable="false" tools:ignore="UnusedResources">pk.eyJ1IjoibWF1cmljaW8tZmIiLCJhIjoiY21icXI4MGkzMDJjMjJqb3BxODN0Z2VvcSJ9.5bf6K8q_U5TCjeRBZ1mM5Q</string>
 </resources>

--- a/core/presentation/designsystem/src/main/res/values/strings.xml
+++ b/core/presentation/designsystem/src/main/res/values/strings.xml
@@ -70,8 +70,7 @@
     <string name="details">Details</string>
     <string name="hotel">Hotel</string>
     <string name="sqm">%1$s sqm</string>
-
-
+    <string name="no_results_found">No activities found in that location, please try with a different city.</string>
 
 
 </resources>


### PR DESCRIPTION
-Incorporated the recommended hotels carousel

![image](https://github.com/user-attachments/assets/21417483-cfd5-4e9d-9761-130955f737ee)

-Incorporated navigation from recommended hotels to hotel detail
-Incorporated hotels in the favorite hotels screen

![image](https://github.com/user-attachments/assets/8821e792-c11d-4dd5-93cc-bb7ce558036e)

-Fixed navigation being handled in some screens instead of the Navigation Root
-Returned the Circular Progress Indicator in Activity Detail

![image](https://github.com/user-attachments/assets/0fd66df5-dfb3-493d-bd38-be2e99758fb0)

-Fixed location not showing as expected in VerticalFavoriteCards
-Added a message when no activities were found in certain locations

![image](https://github.com/user-attachments/assets/5a7240ef-684f-4ea9-8d86-84f570d1c972)

-Abstracted some usecases to be able to do some tests.